### PR TITLE
Add get_lo functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,17 @@ puts HandRank.explain( rank )
 #    Rank: 20490 Category: 5 Rank in category: 10
 ```
 
+#### Get low combination rank
+
+```
+require 'hand_rank/get_lo'
+
+# ["As", "6d", "2c", "5d", "4c"]
+HandRank.get_lo([52, 18, 1, 14, 9]) # => 46
+```
+
+Keep in mind, that the best combination is 56th and the worst is 1.
+
 #### Rank to hand (optional)
 
 ```ruby

--- a/lib/hand_rank/get_lo.rb
+++ b/lib/hand_rank/get_lo.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module HandRank
+  class GetLo
+    HAND_RANKS = %w[A 2 3 4 5 6 7 8].freeze
+
+    # Will be used to avoid any hassle with initial cards sorting (and sorting itself)
+    # we do not use primes module here, since we need only this 8 prime values
+    PRIMES     = [2, 3, 5, 7, 11, 13, 17, 19].freeze
+
+    # Amount of possible low combinations.
+    MAXIMUM_RANK = 56
+
+    class << self
+      def call(*ags)
+        internal_points = ags.flatten.map { |el| absolute_value_as_primitives[el] || 1 }.inject(:*)
+        low_combinations[internal_points]
+      end
+
+      # Produce the Hash, where the key is the multiplication of all hand card,
+      # presented as prime values. The Value contains an `OpenStruct`, which
+      # describes the hand.
+      #
+      # Keep in mind, that keys do not have any correlation with hand strength.
+      #
+      # Returns Hash[Integer]=OpenStruct
+      def low_combinations
+        @low_combinations ||= HAND_RANKS
+                              .combination(5).map.with_index { |el, i| [MAXIMUM_RANK - i, el] }
+                              .each_with_object({}) do |(rank, combination), acc|
+          points = combination.map { |card_rank| PRIMES[HAND_RANKS.index(card_rank)] }.inject(:*)
+          acc[points] = rank
+        end
+      end
+
+      # Basics on `ABSOLUTE_CARD_VALUE_LOOKUP` variable, we create a Hash, for every low
+      # card where the key is a card `absolute_value` and the value is prime number.
+      # This will allow to avoid sorting of the hand.
+      #
+      # Return Hash
+      def absolute_value_as_primitives
+        return @absolute_value_as_primitives if @absolute_value_as_primitives
+
+        prime_generator = PRIMES.each
+        absolute_cards_bases = [12, 0, 1, 2, 3, 4, 5, 6]
+
+        @absolute_value_as_primitives = absolute_cards_bases.each.with_object({}) do |e, acc|
+          prime = prime_generator.next
+          4.times { |i| acc[e * 4 + i + 1] = prime }
+        end
+      end
+    end
+  end
+
+  def get_lo(*args)
+    GetLo.call(*args)
+  end
+
+  module_function :get_lo
+end

--- a/spec/get_lo_spec.rb
+++ b/spec/get_lo_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'hand_rank/get_lo'
+
+RSpec.describe HandRank::GetLo do
+  def self.as_absolute_values(*args)
+    args.flatten.map{|card| ranks[card] }
+  end
+
+  def as_absolute_values(*args)
+    self.class.as_absolute_values(*args)
+  end
+
+
+  describe '.absolute_value_as_primitives' do
+    it { expect(described_class.absolute_value_as_primitives).to be_a Hash }
+    it { expect(described_class.absolute_value_as_primitives[1]).to eq 3 }
+    it { expect(described_class.absolute_value_as_primitives[2]).to eq 3 }
+    it { expect(described_class.absolute_value_as_primitives[3]).to eq 3 }
+    it { expect(described_class.absolute_value_as_primitives[4]).to eq 3 }
+    it { expect(described_class.absolute_value_as_primitives[5]).to eq 5 }
+
+    it { expect(described_class.absolute_value_as_primitives[28]).to eq 19 }
+    it { expect(described_class.absolute_value_as_primitives[29]).to be_nil }
+    it { expect(described_class.absolute_value_as_primitives[48]).to be_nil }
+    it { expect(described_class.absolute_value_as_primitives[49]).to eq 2 }
+    it { expect(described_class.absolute_value_as_primitives[52]).to eq 2 }
+  end
+
+  describe '.low_combinations' do
+    it { expect(described_class.low_combinations).to be_a Hash }
+    it { expect(described_class.low_combinations.keys).to all(be_a_kind_of(Integer)) }
+    it { expect(described_class.low_combinations.values).to all(be_a_kind_of(Integer)) }
+  end
+
+  describe '.call' do
+    it('with out cards') { expect(described_class.call).to be_nil }
+    it('with out low card') { expect(described_class.call(39)).to be_nil }
+    it('with doubled card rank') { expect(described_class.call(as_absolute_values(%w[As Ad 2c 5d 4c]))).to be_nil }
+
+    context 'cards order does not matter with out low' do
+      cards = as_absolute_values(%w[As Ad 2c 5d 4c])
+      cards.permutation.each do |combination|
+        it("with doubled card rank, as combination absolute cards values #{combination.inspect} returns nil") do
+          expect(described_class.call(combination)).to be_nil
+        end
+      end
+    end
+
+    context 'cards order does not matter with low' do
+      cards = as_absolute_values(%w[As 6d 2c 5d 4c])
+      cards.permutation.each do |combination|
+        it("with doubled card rank, as combination absolute cards values #{combination.inspect} returns OpenStruct") do
+          expect(described_class.call(combination)).to eq 46
+        end
+      end
+    end
+
+    [
+        { cards: %w[As 6d 2c 5d 4c], rank: 46 },
+        { cards: %w[As 3d 4c 5d 2c], rank: 56 },
+        { cards: %w[As 3d 4c 6d 2c], rank: 55 },
+        { cards: %w[7s 3d 4c 6d 2c], rank: 18 },
+        { cards: %w[7s 3d 8c 6d 2c], rank: 12 },
+        { cards: %w[7s 5d 8c 6d 4c], rank: 1  },
+    ].each do |condition|
+      it("detects the combination #{condition[:cards]}") do
+        expect(described_class.call(as_absolute_values(condition[:cards]))).to eq condition[:rank]
+      end
+    end
+  end
+end

--- a/spec/hand_to_rank_spec.rb
+++ b/spec/hand_to_rank_spec.rb
@@ -11,14 +11,6 @@ RSpec.describe HandRank do
     end
   end
 
-  def ranks
-    @ranks ||= {}.tap do |acc|
-      %w[2 3 4 5 6 7 8 9 T J Q K A].each_with_index do |rank, ri|
-        %w[c d h s].each_with_index { |suit, si| acc["#{rank}#{suit}"] = ri * 4 + si + 1 }
-      end
-    end
-  end
-
   combinations.each do |combination|
     context(combination) do
       context 'calculate hand_rank points from the backuped hand' do

--- a/spec/helpers/ranks.rb
+++ b/spec/helpers/ranks.rb
@@ -1,0 +1,14 @@
+module RanksHelper
+  def ranks
+    @ranks ||= {}.tap do |acc|
+      %w[2 3 4 5 6 7 8 9 T J Q K A].each_with_index do |rank, ri|
+        %w[c d h s].each_with_index { |suit, si| acc["#{rank}#{suit}"] = ri * 4 + si + 1 }
+      end
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include RanksHelper
+  config.extend RanksHelper
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,10 @@ require 'hand_rank/rank_to_hand'
 
 SPEC_ROOT = Pathname.new(File.expand_path('.', __dir__))
 
+Pathname.glob(SPEC_ROOT.join('helpers', '*.rb')).each do |helper|
+  require helper
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'


### PR DESCRIPTION
Add `get_lo` method, which allows to detect low combination with out pre-sorting.

All required data is pre-calculated and stored in memory (we have only 56 possible low combinations)
This makes possible to find low combinations really quickly.

Keep in mind, that for consistency the best combination have the biggest rank.